### PR TITLE
SignerPOW, hardcoded parameters and staking rewards fixes

### DIFF
--- a/Block/Block.cs
+++ b/Block/Block.cs
@@ -10,6 +10,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // MIT License for more details.
 
+using DLT.Meta;
 using IXICore.Meta;
 using IXICore.Utils;
 using System;
@@ -2241,6 +2242,66 @@ namespace IXICore
                 {
                     result.Add((merged_signature.recipientPubKeyOrAddress, 1));
                 }
+            }
+            if (version < BlockVer.v10)
+            {
+                result.Sort((x, y) => _ByteArrayComparer.Compare(x.address.addressNoChecksum, y.address.addressNoChecksum));
+            }
+            //result = result.OrderBy(x => x.difficulty, Comparer<IxiNumber>.Default).ThenBy(x => x.address.addressNoChecksum, new ByteArrayComparer()).ToList();
+            return result;
+        }
+
+        /// <summary>
+        ///  Retrieves a list of Ixian Wallet addresses from the list of signatures only on this block for stakers .
+        /// </summary>
+        /// <returns>List of Ixian wallets which have signed this block and enough balance.</returns>
+        public List<(Address address, IxiNumber difficulty)> getAppliableSignaturesWalletAddresses()
+        {
+            if (compacted)
+            {
+                throw new Exception($"Trying to get signatures wallet addresses on a compacted block {blockNum}");
+            }
+
+            List<(Address address, IxiNumber difficulty)> result = new List<(Address, IxiNumber)>();
+
+            List<BlockSignature> tmp_sigs;
+            Block? tar_block = IxianHandler.getLastBlock();
+            if (tar_block == null){
+                return result;
+            }
+            ulong blocknum = 0;
+            lock (signatures)
+            {
+                if (frozenSignatures != null)
+                {
+                    tmp_sigs = frozenSignatures;
+                    blocknum = tar_block.blockNum - 1;
+                }
+                else
+                {
+                    tmp_sigs = signatures;
+                    blocknum = tar_block.blockNum;
+                }
+            }
+
+            foreach (BlockSignature merged_signature in tmp_sigs)
+            {
+                // Check ixian amount at wallet
+                IxiNumber balance = Node.walletState.getWallet(merged_signature.recipientPubKeyOrAddress).balance;
+                // Add the address to the list 
+                // without low balance and NO signerPow results
+                if ( ConsensusConfig.minimumMasterNodeFunds > balance )
+                {
+                    continue;
+                }
+                if (merged_signature.powSolution != null)
+                {
+                    result.Add((merged_signature.recipientPubKeyOrAddress, merged_signature.powSolution.difficulty));
+                }
+                // else
+                // {
+                    // result.Add((merged_signature.recipientPubKeyOrAddress, 1));
+                // }
             }
             if (version < BlockVer.v10)
             {

--- a/Block/Block.cs
+++ b/Block/Block.cs
@@ -2294,7 +2294,7 @@ namespace IXICore
                 {
                     continue;
                 }
-                if (merged_signature.powSolution != null)
+                if (merged_signature.powSolution != null && merged_signature.blockNum == blocknum)
                 {
                     result.Add((merged_signature.recipientPubKeyOrAddress, merged_signature.powSolution.difficulty));
                 }

--- a/Meta/ConsensusConfig.cs
+++ b/Meta/ConsensusConfig.cs
@@ -270,8 +270,8 @@ namespace IXICore
         public static readonly long blockChainRecoveryMissingRequiredSignerRatio = 100;
         public static readonly long blockChainRecoveryMissingSignerMultiplier = 7;
 
-        public static readonly ulong sigfreezeOffset = 1;
-        public static readonly ulong sigOverlapOffset = 2;
+        public static readonly ulong sigfreezeOffset = 5;
+        public static readonly ulong sigOverlapOffset = 6;
         public static readonly ulong requiredConsensusOffset = 7;
         public static readonly ulong averageSigCalculationBlockCount = 10;
 

--- a/Meta/ConsensusConfig.cs
+++ b/Meta/ConsensusConfig.cs
@@ -270,8 +270,8 @@ namespace IXICore
         public static readonly long blockChainRecoveryMissingRequiredSignerRatio = 100;
         public static readonly long blockChainRecoveryMissingSignerMultiplier = 7;
 
-        public static readonly ulong sigfreezeOffset = 5;
-        public static readonly ulong sigOverlapOffset = 6;
+        public static readonly ulong sigfreezeOffset = 1;
+        public static readonly ulong sigOverlapOffset = 2;
         public static readonly ulong requiredConsensusOffset = 7;
         public static readonly ulong averageSigCalculationBlockCount = 10;
 

--- a/Meta/ConsensusConfig.cs
+++ b/Meta/ConsensusConfig.cs
@@ -114,7 +114,7 @@ namespace IXICore
         /// <summary>
         /// Minimum funds a wallet must have before it is allowed to participate in the block consensus algorithm. (used in DLT Node executable).
         /// </summary>
-        public static readonly IxiNumber minimumMasterNodeFunds = new IxiNumber("0");
+        public static readonly IxiNumber minimumMasterNodeFunds = new IxiNumber("1000000");
         /// <summary>
         /// Transaction fee per kilobyte. Total transaction size is used. (Used in DLT Node executable.) 
         /// </summary>

--- a/Miner/SignerPowMiner.cs
+++ b/Miner/SignerPowMiner.cs
@@ -190,7 +190,7 @@ namespace IXICore.Miner
 
             if (candidateBlock.timestamp + 1800 < Clock.getNetworkTimestamp())
             {
-                candidateBlock = IxianHandler.getBlockHeader(candidateBlock.blockNum - 6);
+                candidateBlock = IxianHandler.getBlockHeader(candidateBlock.blockNum - ConsensusConfig.sigOverlapOffset);
             }
 
             if (candidateBlock == null)

--- a/Miner/SignerPowMiner.cs
+++ b/Miner/SignerPowMiner.cs
@@ -200,6 +200,18 @@ namespace IXICore.Miner
             ulong lastBlockHeight = candidateBlock.blockNum;
             ulong minCalculationBlockCount = ConsensusConfig.getPlPowMinCalculationBlockTime(IxianHandler.getLastBlockVersion());
 
+            // Restricts SignerPow after FIRST fine solution
+
+            if (currentBlockHeight > 0 && lastFoundBlockHeight > 0)
+            {
+                if ( lastFoundBlockHeight + ConsensusConfig.getPlPowBlocksValidity() > IxianHandler.getLastBlockHeight() )
+                {
+                    // Stop mining on all threads
+                    currentBlockHeight = 0;
+                    ResetStats();
+                    return;
+                }
+            }
             if (currentBlockHeight > 0)
             {
                 // Check if we're mining for at least X blocks and that the blockchain isn't stuck

--- a/Miner/SignerPowMiner.cs
+++ b/Miner/SignerPowMiner.cs
@@ -158,8 +158,10 @@ namespace IXICore.Miner
                             blockHeight = block.blockNum;
                         }
                     }
-
-                    CalculateHash(blockHeight, keyPair, challenge);
+                    if (currentBlockHeight != 0)
+                    {
+                        CalculateHash(blockHeight, keyPair, challenge);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Transaction/Transaction.cs
+++ b/Transaction/Transaction.cs
@@ -2641,7 +2641,7 @@ namespace IXICore
             Array.Copy(txid, type_len + bh_len, tx_hash, 0, tx_hash.Length);
             if (type == 0)
             {
-                s_txid = "stk-" + (bh - 5) + "-" + bh + "-" + Base58Check.Base58CheckEncoding.EncodePlain(tx_hash);
+                s_txid = "stk-" + (bh - ConsensusConfig.sigfreezeOffset) + "-" + bh + "-" + Base58Check.Base58CheckEncoding.EncodePlain(tx_hash);
             }
             else
             {

--- a/Transaction/TransactionInclusion.cs
+++ b/Transaction/TransactionInclusion.cs
@@ -1301,7 +1301,7 @@ namespace IXICore
                 throw new Exception("Current block timestamp must be provided to calculate required signer difficulty.");
             }
             ulong blockNum = lastBlockHeader.blockNum + 1;
-            ulong blockOffset = 7;
+            ulong blockOffset = ConsensusConfig.requiredConsensusOffset;
             if (blockNum < blockOffset + 1) return ConsensusConfig.minBlockSignerPowDifficulty; // special case for first X blocks - since sigFreeze happens n-5 blocks
 
             if (cachedRequiredSignerDifficulty.BlockNum == blockNum


### PR DESCRIPTION
SignerPow and SigFreeze works with no logic conflicts. 
Hardcoded numbers replaced with real ConsensusConfig. Consensus params leaved unchanged except ixiamount =)